### PR TITLE
[MA-63] Load model weights from local

### DIFF
--- a/src/img2img/config.py
+++ b/src/img2img/config.py
@@ -22,7 +22,10 @@ class Config:
     )
 
     # SAM
-    sam_checkpoint = "../models/sam_vit_h_4b8939.pth"
+    sam_checkpoint = "../models/sam/sam_vit_h_4b8939.pth"
     model_type = "vit_h"
+
+    # InstructPix2Pix
+    p2p_model_id = "../models/instruct-pix2pix"
 
 cfg = Config()

--- a/src/img2img/load_models.py
+++ b/src/img2img/load_models.py
@@ -49,7 +49,7 @@ def load_sam():
 
 # InstructPix2Pix
 def load_instructpix2pix():
-    model_id = "timbrooks/instruct-pix2pix"
+    model_id = cfg.p2p_model_id
     pipe = StableDiffusionInstructPix2PixPipeline.from_pretrained(model_id, torch_dtype=torch.float16, safety_checker=None)
     pipe.to(cfg.device)
     pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config)


### PR DESCRIPTION
## Background
- Enable model loading from local directory.

## Details
- Load model weights from local directory instead of huggingface hub.

## Test
- Tested that the model generates the same results as before.